### PR TITLE
Support proxying of extension types

### DIFF
--- a/org.gecko.rest.jersey/bnd.bnd
+++ b/org.gecko.rest.jersey/bnd.bnd
@@ -27,7 +27,8 @@
 	org.apache.geronimo.specs.geronimo-jaxrs_2.1_spec,\
 	biz.aQute.bnd.annotation,\
 	org.gecko.rest.jersey.sse;version=latest,\
-	jakarta.inject.jakarta.inject-api
+	jakarta.inject.jakarta.inject-api,\
+	org.objectweb.asm;version='9.3'
 
 -testpath: ${junit},\
 	org.mockito.mockito-core,\
@@ -70,6 +71,7 @@ Provide-Capability: \
 	org.gecko.rest.jersey.dto,\
 	org.gecko.rest.jersey.factories,\
 	org.gecko.rest.jersey.jetty,\
+	org.gecko.rest.jersey.proxy,\
 	org.gecko.rest.jersey.runtime,\
 	org.gecko.rest.jersey.runtime.application,\
 	org.gecko.rest.jersey.runtime.application.feature,\

--- a/org.gecko.rest.jersey/src/org/gecko/rest/jersey/provider/application/JaxRsExtensionProvider.java
+++ b/org.gecko.rest.jersey/src/org/gecko/rest/jersey/provider/application/JaxRsExtensionProvider.java
@@ -11,6 +11,9 @@
  */
 package org.gecko.rest.jersey.provider.application;
 
+import java.util.Map;
+
+import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.osgi.service.jaxrs.runtime.dto.BaseExtensionDTO;
 
 /**
@@ -39,4 +42,32 @@ public interface JaxRsExtensionProvider extends JaxRsApplicationContentProvider 
 	 * @return the Array of Classes
 	 */
 	public Class<?>[] getContracts();
+	
+	/**
+	 * Returns an Extension instance suitable for binding into an application. This extension must be
+	 * disposed once it is finished with
+	 * @param injectionManager 
+	 * @return the extension
+	 */
+	public JaxRsExtension getExtension(InjectionManager injectionManager);
+	
+	public interface JaxRsExtension {
+		
+		/**
+		 * Returns the contract priorities for this extension. The keys will match the values returned by
+		 * {@link JaxRsExtensionProvider#getContracts()}
+		 * @return the Contract priorities
+		 */
+		public Map<Class<?>, Integer> getContractPriorities();
+		
+		/**
+		 * Get the extension object
+		 */
+		public Object getExtensionObject();
+		
+		/**
+		 * Release the extension object
+		 */
+		public void dispose();
+	}
 }

--- a/org.gecko.rest.jersey/src/org/gecko/rest/jersey/proxy/ExtensionProxyFactory.java
+++ b/org.gecko.rest.jersey/src/org/gecko/rest/jersey/proxy/ExtensionProxyFactory.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2012 - 2022 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Data In Motion - initial API and implementation
+ */
+package org.gecko.rest.jersey.proxy;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.signature.SignatureVisitor;
+import org.objectweb.asm.signature.SignatureWriter;
+
+/**
+ * This class is used to generate proxies for extension services
+ * 
+ * The proxy will:
+ * 
+ * * Implement all of the contract interfaces
+ * * Have the same generic signature for each interface implemented
+ * * Extend Object
+ * * Delegate to 
+ * 
+ * 
+ * @author timothyjward
+ * @since 9 May 2022
+ */
+public class ExtensionProxyFactory {
+	
+	private static final String OBJECT_INTERNAL_NAME = Type.getInternalName(Object.class);
+
+	/**
+	 * @param simpleName
+	 */
+	public static byte[] generateClass(String className, Object delegate, List<Class<?>> contracts) {
+		Map<String, ParameterizedType> typeInfo = Arrays.stream(delegate.getClass().getGenericInterfaces())
+				.filter(ParameterizedType.class::isInstance)
+				.map(ParameterizedType.class::cast)
+				.collect(Collectors.toMap(i -> i.getRawType().getTypeName(), Function.identity()));
+		
+		
+		String sig = generateGenericClassSignature(typeInfo, contracts);
+		
+		
+		try {
+			ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+			
+			String internalName = className.replace('.', '/');
+			cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, internalName, 
+					sig, OBJECT_INTERNAL_NAME, 
+					contracts.stream()
+						.map(Type::getInternalName)
+						.toArray(String[]::new));
+			
+			for (Annotation annotation : delegate.getClass().getAnnotations()) {
+				AnnotationVisitor av = cw.visitAnnotation(Type.getDescriptor(annotation.annotationType()), true);
+				visitAnnotationMembers(annotation, av);
+				av.visitEnd();
+			}
+		
+			cw.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL, "delegateSupplier", Type.getDescriptor(Supplier.class), null, null).visitEnd();
+			
+			MethodVisitor constructor = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(Ljava/util/function/Supplier;)V", null, null);
+			constructor.visitCode();
+			constructor.visitVarInsn(Opcodes.ALOAD, 0);
+			constructor.visitMethodInsn(Opcodes.INVOKESPECIAL, OBJECT_INTERNAL_NAME, 
+					"<init>", "()V", false);
+			constructor.visitVarInsn(Opcodes.ALOAD, 0);
+			constructor.visitVarInsn(Opcodes.ALOAD, 1);
+			constructor.visitFieldInsn(Opcodes.PUTFIELD, internalName, "delegateSupplier", Type.getDescriptor(Supplier.class));
+			constructor.visitInsn(Opcodes.RETURN);
+			constructor.visitMaxs(2, 2);
+			constructor.visitEnd();
+			
+			for(Class<?> contract : contracts) {
+				for(Method m : contract.getMethods()) {
+					MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, m.getName(), Type.getMethodDescriptor(m), null, 
+							Arrays.stream(m.getExceptionTypes()).map(Type::getInternalName).toArray(String[]::new));
+					mv.visitCode();
+					mv.visitVarInsn(Opcodes.ALOAD, 0);
+					mv.visitFieldInsn(Opcodes.GETFIELD, internalName, "delegateSupplier", Type.getDescriptor(Supplier.class));
+					mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(Supplier.class), "get", 
+							Type.getMethodDescriptor(Supplier.class.getMethod("get")), true);
+					mv.visitTypeInsn(Opcodes.CHECKCAST, Type.getInternalName(contract));
+					for(int i = 0; i < m.getParameterCount(); i++) {
+						mv.visitVarInsn(Opcodes.ALOAD, i + 1);
+					}
+					mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, Type.getInternalName(contract), m.getName(), 
+							Type.getMethodDescriptor(m), true);
+					if(m.getReturnType().equals(Void.TYPE)) {
+						mv.visitInsn(Opcodes.RETURN);
+					} else if (m.getReturnType() == boolean.class || m.getReturnType() == byte.class || 
+							m.getReturnType() == char.class || m.getReturnType() == int.class) {
+						mv.visitInsn(Opcodes.IRETURN);
+					} else if (m.getReturnType() == long.class ) {
+						mv.visitInsn(Opcodes.LRETURN);
+					} else if (m.getReturnType() == float.class ) {
+						mv.visitInsn(Opcodes.FRETURN);
+					} else if (m.getReturnType() == double.class ) {
+						mv.visitInsn(Opcodes.DRETURN);
+					} else {
+						mv.visitInsn(Opcodes.ARETURN);
+					}
+					mv.visitMaxs(m.getParameterCount() + 1, m.getParameterCount() + 1);
+					mv.visitEnd();
+				}
+			}
+			
+			cw.visitEnd();
+			
+			return cw.toByteArray();
+		
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * @param typeInfo
+	 * @return
+	 */
+	private static String generateGenericClassSignature(Map<String, ParameterizedType> typeInfo, List<Class<?>> contracts) {
+		if(typeInfo.isEmpty()) {
+			return null;
+		}
+		
+		SignatureWriter sw = new SignatureWriter();
+		// Handle parent
+		SignatureVisitor sv = sw.visitSuperclass();
+		sv.visitClassType(OBJECT_INTERNAL_NAME);
+		sv.visitEnd();
+		
+		// Handle interfaces
+		for(Class<?> contract : contracts) {
+			if(typeInfo.containsKey(contract.getName())) {
+				SignatureVisitor iv = sw.visitInterface();
+				iv.visitClassType(Type.getInternalName(contract));
+				for(java.lang.reflect.Type t : typeInfo.get(contract.getName()).getActualTypeArguments()) {
+					visitTypeParameter(t, iv);
+				}
+				iv.visitEnd();
+			}
+		}
+		 
+		sw.visitEnd();
+		return sw.toString();
+	}
+
+	private static void visitTypeParameter(java.lang.reflect.Type t, SignatureVisitor sv) {
+		SignatureVisitor pv = sv.visitTypeArgument('=');
+		if(t instanceof Class<?>) {
+			Class<?> clazz = (Class<?>) t;
+			if(clazz.isPrimitive()) {
+				pv.visitBaseType(Type.getDescriptor(clazz).charAt(0));
+			} else if (clazz.isArray()) {
+				SignatureVisitor av = pv.visitArrayType();
+				visitTypeParameter(clazz.getComponentType(), av);
+				av.visitEnd();
+			} else {
+				pv.visitClassType(Type.getInternalName(clazz));
+			}
+		} else if (t instanceof ParameterizedType){
+			ParameterizedType pt = (ParameterizedType) t;
+			pv.visitClassType(Type.getInternalName((Class<?>)pt.getRawType()));
+			Arrays.stream(pt.getActualTypeArguments()).forEach(ta -> visitTypeParameter(ta, pv));
+		}
+		pv.visitEnd();
+	}
+	
+	private static void visitAnnotationMembers(Annotation a, AnnotationVisitor av) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+		for (Method method : a.annotationType().getDeclaredMethods()) {
+			Class<?> returnType = method.getReturnType();
+			if(returnType.isAnnotation()) {
+				AnnotationVisitor av2 = av.visitAnnotation(method.getName(), Type.getDescriptor(returnType));
+				visitAnnotationMembers((Annotation)method.invoke(av2), av2);
+				av2.visitEnd();
+			} else if(returnType.isEnum()) {
+				Enum<?> e = (Enum<?>) method.invoke(a);
+				av.visitEnum(method.getName(), Type.getInternalName(returnType), e.name());
+			} else if (returnType.isArray() && !returnType.getComponentType().isPrimitive()) {
+				AnnotationVisitor av2 = av.visitArray(method.getName());
+				Object[] values = (Object[]) method.invoke(a);
+				if(returnType.getComponentType().isAnnotation()) {
+					for(Object o : values) {
+						visitAnnotationMembers((Annotation) o, av2);
+					}
+				} else if(returnType.getComponentType().isEnum()) {
+					String enumType = Type.getInternalName(returnType.getComponentType());
+					for(Object o : values) {
+						av2.visitEnum(null, enumType, ((Enum<?>)o).name());
+					}
+				} else {
+					for(Object o : values) {
+						av2.visit(null, o);
+					}
+				}
+				av2.visitEnd();
+			} else {
+				av.visit(method.getName(), method.invoke(a));
+			}
+		}
+	}
+	
+	/**
+	 * @return
+	 */
+	public static String getSimpleName(Integer rank, Long id) {
+		long serviceRank = (rank.longValue() - (long) Integer.MAX_VALUE) * -1;
+		long serviceId = id.longValue();
+		
+		String rankHex = Long.toHexString(serviceRank);
+		if(rankHex.length() < 8) {
+			rankHex = "00000000".substring(rankHex.length(), 8).concat(rankHex);
+		}
+		String idHex = Long.toHexString(serviceId);
+		if(idHex.length() < 16) {
+			idHex = "0000000000000000".substring(idHex.length(), 16).concat(idHex);
+		}
+		String simpleName = String.format("Extension_%s_%s", rankHex, idHex);
+		return simpleName;
+	}
+	
+}

--- a/org.gecko.rest.jersey/test/org/gecko/rest/jersey/proxy/ExtensionProxyTest.java
+++ b/org.gecko.rest.jersey/test/org/gecko/rest/jersey/proxy/ExtensionProxyTest.java
@@ -1,0 +1,302 @@
+/**
+ * Copyright (c) 2012 - 2022 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Data In Motion - initial API and implementation
+ */
+package org.gecko.rest.jersey.proxy;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * 
+ * @author timothyjward
+ * @since 9 May 2022
+ */
+@RunWith(JUnit4.class)
+public class ExtensionProxyTest {
+
+	PublicClassLoader pcl = new PublicClassLoader();
+	
+	@Test
+	public void testNameOrdering() {
+		assertEquals(ExtensionProxyFactory.getSimpleName(0, 1L), 
+				ExtensionProxyFactory.getSimpleName(0, 1L));
+		
+		assertTrue(ExtensionProxyFactory.getSimpleName(1, 1L)
+				.compareTo(ExtensionProxyFactory.getSimpleName(0, 2L)) < 0);
+		assertTrue(ExtensionProxyFactory.getSimpleName(0, 1L)
+				.compareTo(ExtensionProxyFactory.getSimpleName(-1, 2L)) < 0);
+		assertTrue(ExtensionProxyFactory.getSimpleName(0, 1L)
+				.compareTo(ExtensionProxyFactory.getSimpleName(0, 2L)) < 0);
+		assertTrue(ExtensionProxyFactory.getSimpleName(-1, 1L)
+				.compareTo(ExtensionProxyFactory.getSimpleName(0, 2L)) > 0);
+		assertTrue(ExtensionProxyFactory.getSimpleName(0, 1L)
+				.compareTo(ExtensionProxyFactory.getSimpleName(1, 2L)) > 0);
+	}
+	
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testExceptionMapper() throws Exception {
+		
+		ExceptionMapper<NullPointerException> em = new TestExceptionMapper();
+		
+		Class<?> proxyClazz = pcl.define("test.ExceptionMapper", em, 
+				singletonList(ExceptionMapper.class));
+		
+		assertTrue(ExceptionMapper.class.isAssignableFrom(proxyClazz));
+		Type[] genericInterfaces = proxyClazz.getGenericInterfaces();
+		
+		assertEquals(1, genericInterfaces.length);
+		assertTrue(genericInterfaces[0] instanceof ParameterizedType);
+		ParameterizedType pt = (ParameterizedType) genericInterfaces[0];
+		assertEquals(ExceptionMapper.class, pt.getRawType());
+		assertEquals(NullPointerException.class, pt.getActualTypeArguments()[0]);
+	
+		
+		Object instance = proxyClazz.getConstructor(Supplier.class)
+			.newInstance((Supplier<?>) () -> em);
+		
+		assertEquals(418, ((ExceptionMapper<NullPointerException>)instance)
+				.toResponse(new NullPointerException()).getStatus());
+		
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	public void testRawExceptionMapper() throws Exception {
+		
+		ExceptionMapper em = new RawExceptionMapper();
+		
+		Class<?> proxyClazz = pcl.define("test.RawExceptionMapper", em, 
+				singletonList(ExceptionMapper.class));
+		
+		assertTrue(ExceptionMapper.class.isAssignableFrom(proxyClazz));
+		Type[] genericInterfaces = proxyClazz.getGenericInterfaces();
+		
+		assertEquals(1, genericInterfaces.length);
+		assertEquals(ExceptionMapper.class, genericInterfaces[0]);
+		
+		Object instance = proxyClazz.getConstructor(Supplier.class)
+				.newInstance((Supplier<?>) () -> em);
+		
+		assertEquals(814, ((ExceptionMapper)instance)
+				.toResponse(new OutOfMemoryError()).getStatus());
+		
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testAnnotatedExceptionMapper() throws Exception {
+		
+		ExceptionMapper<IllegalArgumentException> em = new AnnotatedExceptionMapper();
+		
+		Class<?> proxyClazz = pcl.define("test.AnnotatedExceptionMapper", em, 
+				singletonList(ExceptionMapper.class));
+		
+		assertTrue(ExceptionMapper.class.isAssignableFrom(proxyClazz));
+		Type[] genericInterfaces = proxyClazz.getGenericInterfaces();
+		
+		assertEquals(1, genericInterfaces.length);
+		assertTrue(genericInterfaces[0] instanceof ParameterizedType);
+		ParameterizedType pt = (ParameterizedType) genericInterfaces[0];
+		assertEquals(ExceptionMapper.class, pt.getRawType());
+		assertEquals(IllegalArgumentException.class, pt.getActualTypeArguments()[0]);
+	
+		
+		assertEquals(1, proxyClazz.getAnnotations().length);
+		assertNotNull(proxyClazz.getAnnotation(Path.class));
+		
+		Path path = proxyClazz.getAnnotation(Path.class);
+		assertEquals("boo", path.value());
+		
+		
+		Object instance = proxyClazz.getConstructor(Supplier.class)
+			.newInstance((Supplier<?>) () -> em);
+		
+		assertEquals(777, ((ExceptionMapper<IllegalArgumentException>)instance)
+				.toResponse(new IllegalArgumentException()).getStatus());
+		
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void testMultiInterfaceMapper() throws Exception {
+		
+		TestMultiInterface mi = new TestMultiInterface();
+		
+		// Deliberately re-order the interfaces relative to the implements clause
+		Class<?> proxyClazz = pcl.define("test.MultiInterface", mi, 
+				Arrays.asList(MessageBodyWriter.class, MessageBodyReader.class));
+		
+		assertTrue(MessageBodyReader.class.isAssignableFrom(proxyClazz));
+		assertTrue(MessageBodyWriter.class.isAssignableFrom(proxyClazz));
+		Type[] genericInterfaces = proxyClazz.getGenericInterfaces();
+		
+		assertEquals(2, genericInterfaces.length);
+		
+		assertTrue(genericInterfaces[0] instanceof ParameterizedType);
+		ParameterizedType pt = (ParameterizedType) genericInterfaces[0];
+		assertEquals(MessageBodyWriter.class, pt.getRawType());
+		assertEquals(Long.class, pt.getActualTypeArguments()[0]);
+
+		assertTrue(genericInterfaces[1] instanceof ParameterizedType);
+		pt = (ParameterizedType) genericInterfaces[1];
+		assertEquals(MessageBodyReader.class, pt.getRawType());
+		assertEquals(Integer.class, pt.getActualTypeArguments()[0]);
+		
+		
+		Object instance = proxyClazz.getConstructor(Supplier.class)
+				.newInstance((Supplier<?>) () -> mi);
+		
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		((MessageBodyWriter) instance).writeTo(42L, Long.class, null, null, null, null, baos);
+		
+		// 2 characters, "2a" 
+		assertArrayEquals(new byte[]{0,2,50,97}, baos.toByteArray());
+		
+		
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		
+		
+		assertEquals(42, ((MessageBodyReader) instance).readFrom(Integer.class, null, null, null, null, bais));
+		
+	}
+
+	public static class TestExceptionMapper implements ExceptionMapper<NullPointerException> {
+
+		/* 
+		 * (non-Javadoc)
+		 * @see javax.ws.rs.ext.ExceptionMapper#toResponse(java.lang.Throwable)
+		 */
+		@Override
+		public Response toResponse(NullPointerException exception) {
+			// I'm a teapot
+			return Response.status(418).build();
+		}
+		
+	}
+
+	@SuppressWarnings("rawtypes")
+	public static class RawExceptionMapper implements ExceptionMapper {
+		
+		/* 
+		 * (non-Javadoc)
+		 * @see javax.ws.rs.ext.ExceptionMapper#toResponse(java.lang.Throwable)
+		 */
+		@Override
+		public Response toResponse(Throwable exception) {
+			// What's an 8xx response?!?
+			return Response.status(814).build();
+		}
+		
+	}
+
+	@Path("boo")
+	public static class AnnotatedExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+		
+		/* 
+		 * (non-Javadoc)
+		 * @see javax.ws.rs.ext.ExceptionMapper#toResponse(java.lang.Throwable)
+		 */
+		@Override
+		public Response toResponse(IllegalArgumentException exception) {
+			// All lucky 7s
+			return Response.status(777).build();
+		}
+		
+	}
+
+	public static class TestMultiInterface implements MessageBodyReader<Integer>, MessageBodyWriter<Long> {
+
+		/* 
+		 * (non-Javadoc)
+		 * @see javax.ws.rs.ext.MessageBodyWriter#isWriteable(java.lang.Class, java.lang.reflect.Type, java.lang.annotation.Annotation[], javax.ws.rs.core.MediaType)
+		 */
+		@Override
+		public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+			return false;
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see javax.ws.rs.ext.MessageBodyWriter#writeTo(java.lang.Object, java.lang.Class, java.lang.reflect.Type, java.lang.annotation.Annotation[], javax.ws.rs.core.MediaType, javax.ws.rs.core.MultivaluedMap, java.io.OutputStream)
+		 */
+		@Override
+		public void writeTo(Long t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+				MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+				throws IOException, WebApplicationException {
+			try(DataOutputStream daos = new DataOutputStream(entityStream)) {
+				daos.writeUTF(Long.toHexString(t));
+			}
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see javax.ws.rs.ext.MessageBodyReader#isReadable(java.lang.Class, java.lang.reflect.Type, java.lang.annotation.Annotation[], javax.ws.rs.core.MediaType)
+		 */
+		@Override
+		public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+			return false;
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see javax.ws.rs.ext.MessageBodyReader#readFrom(java.lang.Class, java.lang.reflect.Type, java.lang.annotation.Annotation[], javax.ws.rs.core.MediaType, javax.ws.rs.core.MultivaluedMap, java.io.InputStream)
+		 */
+		@Override
+		public Integer readFrom(Class<Integer> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+				MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+				throws IOException, WebApplicationException {
+			try (DataInputStream dis = new DataInputStream(entityStream)) {
+				return Integer.valueOf(dis.readUTF(), 16);
+			}
+		}
+	}
+		
+	
+	public static class PublicClassLoader extends ClassLoader {
+		
+		public Class<?> define(String name, Object delegate, List<Class<?>> contracts) {
+			byte[] b = ExtensionProxyFactory.generateClass(name, delegate, contracts);
+			return defineClass(name, b, 0, b.length);
+		}
+	}
+}


### PR DESCRIPTION
Necessary to support registering more than one instance of the same type. ASM must be used to copy generics information and annotations accross to the proxy class. Proxy classes have names generated using the service id and ranking so that the type names sort according to service ranking order. A new instance must be therefore be registered if the extension changes its ranking.

Signed-off-by Tim Ward <timothyjward@apache.org>