### PR TITLE
Set TCCL properly when initializing the whiteboard

### DIFF
--- a/org.gecko.rest.jersey.tck/tck_jakarta.bndrun
+++ b/org.gecko.rest.jersey.tck/tck_jakarta.bndrun
@@ -97,4 +97,4 @@
 -runblacklist: \
 	bnd.identity;id='org.osgi.service.cm',\
 	bnd.identity;id='org.gecko.rest.jersey.servlet.whiteboard'
--runproperties: jakarta.ws.rs.ext.RuntimeDelegate=org.gecko.rest.jersey.provider.jakartars.RuntimeDelegateService
+

--- a/org.gecko.rest.jersey/bnd.bnd
+++ b/org.gecko.rest.jersey/bnd.bnd
@@ -1,5 +1,6 @@
 -buildpath: \
 	org.apache.felix.http.servlet-api;version=latest,\
+	org.glassfish.jersey.containers.jersey-container-servlet;version=latest,\
 	org.glassfish.jersey.containers.jersey-container-servlet-core;version=latest,\
 	org.glassfish.jersey.core.jersey-common;version=latest,\
 	org.glassfish.jersey.core.jersey-client;version=latest,\


### PR DESCRIPTION
This removes the need for a custom property when launching the whiteboard

Also, make sure necessary implementation types are bound to the runtime

Signed-off-by: Tim Ward <timothyjward@apache.org>