### PR TITLE
Tidy up requirements and capabilities

### DIFF
--- a/org.gecko.rest.jersey.jetty/src/org/gecko/rest/jersey/jetty/JerseyServiceRuntime.java
+++ b/org.gecko.rest.jersey.jetty/src/org/gecko/rest/jersey/jetty/JerseyServiceRuntime.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.gecko.rest.jersey.annotations.ProvideRuntimeAdapter;
 import org.gecko.rest.jersey.helper.JakartarsHelper;
 import org.gecko.rest.jersey.helper.JerseyHelper;
 import org.gecko.rest.jersey.provider.JerseyConstants;
@@ -36,14 +37,9 @@ import org.gecko.rest.jersey.runtime.ResourceConfigWrapper;
 import org.gecko.rest.jersey.runtime.WhiteboardServletContainer;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
-import org.osgi.annotation.bundle.Capability;
-import org.osgi.annotation.bundle.Requirement;
-import org.osgi.framework.namespace.IdentityNamespace;
-import org.osgi.namespace.implementation.ImplementationNamespace;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.jakartars.runtime.JakartarsServiceRuntime;
-import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
 
 /**
  * Implementation of the {@link JakartarsServiceRuntime} for a Jetty backed implementation
@@ -51,10 +47,7 @@ import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
  * @author Mark Hoffmann
  * @since 12.07.2017
  */
-@Capability(namespace = ImplementationNamespace.IMPLEMENTATION_NAMESPACE, version = JakartarsWhiteboardConstants.JAKARTA_RS_WHITEBOARD_SPECIFICATION_VERSION, name = JakartarsWhiteboardConstants.JAKARTA_RS_WHITEBOARD_IMPLEMENTATION, attribute = {
-		"uses:=\"jakarta.ws.rs,jakarta.ws.rs.sse,jakarta.ws.rs.core,jakarta.ws.rs.ext,jakarta.ws.rs.client,jakarta.ws.rs.container,org.osgi.service.jakartars.whiteboard\"",
-		"provider=jersey", "jersey.version=3.0" })
-@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.core.jersey-server")
+@ProvideRuntimeAdapter("jetty")
 public class JerseyServiceRuntime extends AbstractJerseyServiceRuntime {
 
 	public enum State {

--- a/org.gecko.rest.jersey.servlet.whiteboard/src/org/gecko/rest/jersey/runtime/httpwhiteboard/ServletWhiteboardBasedJerseyServiceRuntime.java
+++ b/org.gecko.rest.jersey.servlet.whiteboard/src/org/gecko/rest/jersey/runtime/httpwhiteboard/ServletWhiteboardBasedJerseyServiceRuntime.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
+import org.gecko.rest.jersey.annotations.ProvideRuntimeAdapter;
 import org.gecko.rest.jersey.helper.JerseyHelper;
 import org.gecko.rest.jersey.provider.JerseyConstants;
 import org.gecko.rest.jersey.provider.application.JakartarsApplicationProvider;
@@ -31,8 +32,6 @@ import org.gecko.rest.jersey.runtime.ResourceConfigWrapper;
 import org.gecko.rest.jersey.runtime.WhiteboardServletContainer;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
-import org.osgi.annotation.bundle.Capability;
-import org.osgi.annotation.bundle.Requirement;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -41,16 +40,14 @@ import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.PrototypeServiceFactory;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
-import org.osgi.framework.namespace.IdentityNamespace;
-import org.osgi.namespace.implementation.ImplementationNamespace;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.jakartars.runtime.JakartarsServiceRuntime;
-import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
 import org.osgi.service.servlet.context.ServletContextHelper;
 import org.osgi.service.servlet.runtime.HttpServiceRuntime;
 import org.osgi.service.servlet.runtime.HttpServiceRuntimeConstants;
 import org.osgi.service.servlet.whiteboard.HttpWhiteboardConstants;
+import org.osgi.service.servlet.whiteboard.annotations.RequireHttpWhiteboard;
 
 import jakarta.servlet.Servlet;
 
@@ -59,11 +56,8 @@ import jakarta.servlet.Servlet;
  * @author Mark Hoffmann
  * @since 12.07.2017
  */
-@Capability(namespace = ImplementationNamespace.IMPLEMENTATION_NAMESPACE, version = JakartarsWhiteboardConstants.JAKARTA_RS_WHITEBOARD_SPECIFICATION_VERSION, name = JakartarsWhiteboardConstants.JAKARTA_RS_WHITEBOARD_IMPLEMENTATION, attribute = {
-		"uses:=\"jakarta.ws.rs,jakarta.ws.rs.sse,jakarta.ws.rs.core,jakarta.ws.rs.ext,jakarta.ws.rs.client,jakarta.ws.rs.container,org.osgi.service.jakartars.whiteboard\"",
-		"provider=jersey", "jersey.version=3.0" })
-@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.core.jersey-server")
-@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.containers.jersey-container-servlet")
+@ProvideRuntimeAdapter(HttpWhiteboardConstants.HTTP_WHITEBOARD_IMPLEMENTATION)
+@RequireHttpWhiteboard
 public class ServletWhiteboardBasedJerseyServiceRuntime extends AbstractJerseyServiceRuntime {
 
 	private final Map<String, ServiceRegistration<Servlet>> applicationServletRegistrationMap = new ConcurrentHashMap<>();

--- a/org.gecko.rest.jersey/bnd.bnd
+++ b/org.gecko.rest.jersey/bnd.bnd
@@ -10,6 +10,7 @@
 	org.osgi.annotation.versioning;version=latest,\
 	org.osgi.annotation.bundle;version=latest,\
 	org.osgi.namespace.implementation;version=latest,\
+	org.osgi.namespace.service;version=latest,\
 	org.osgi.framework;version=latest,\
 	org.osgi.dto;version=latest,\
 	org.osgi.resource;version=latest,\
@@ -35,12 +36,8 @@
 Bundle-Name: Gecko Jakartars Whiteboard
 Bundle-Description: Gecko Jersey OSGi Jakartars Whiteboard implementation
 	
-Provide-Capability: \
-	osgi.contract; osgi.contract=JavaJAXRS; version:List<Version>="2.1,2";provider=jersey;jersey.version:Version="3.08";uses:="jakarta.ws.rs, jakarta.ws.rs.core, jakarta.ws.rs.sse, jakarta.ws.rs.ext, jakarta.ws.rs.client, jakarta.ws.rs.container",\
-	osgi.service;objectClass:List<String>="org.osgi.service.jakartars.runtime.JakartarsServiceRuntime";uses:="org.osgi.service.jakartars.runtime,org.osgi.service.jakartars.runtime.dto",\
-	osgi.service;objectClass:List<String>="jakarta.ws.rs.client.ClientBuilder";uses:="jakarta.ws.rs.client,org.osgi.service.jakartars.client";service.scope="prototype",\
-	osgi.service;objectClass:List<String>="org.osgi.service.jakartars.client.SseEventSourceFactory";uses:="org.osgi.service.jakartars.client",\
-	osgi.serviceloader;osgi.serviceloader="jakarta.ws.rs.sse.SseEventSource.Builder";register:="org.gecko.rest.jersey.runtime.common.SSESourceBuilderService
+#Provide-Capability: \
+#osgi.serviceloader;osgi.serviceloader="jakarta.ws.rs.sse.SseEventSource.Builder";register:="org.gecko.rest.jersey.runtime.common.SSESourceBuilderService
 
 	
 Import-Package: \

--- a/org.gecko.rest.jersey/src/org/gecko/rest/jersey/annotations/ProvideRuntimeAdapter.java
+++ b/org.gecko.rest.jersey/src/org/gecko/rest/jersey/annotations/ProvideRuntimeAdapter.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2012 - 2022 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made available under the terms of the 
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * Contributors:
+ *     Data In Motion - initial API and implementation
+ *     Stefan Bishof - API and implementation
+ *     Tim Ward - implementation
+ */
+package org.gecko.rest.jersey.annotations;
+
+import static org.osgi.namespace.implementation.ImplementationNamespace.IMPLEMENTATION_NAMESPACE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.osgi.annotation.bundle.Attribute;
+import org.osgi.annotation.bundle.Capability;
+
+/**
+ * Require a Runtime Adapter bundle to host the whiteboard on an underlying servlet runtime,
+ * 
+ * e.g. A Jetty server, or the OSGi Servlet Whiteboard
+ * 
+ * @author Mark Hoffmann
+ * @since 07.11.2022
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({
+		ElementType.TYPE, ElementType.PACKAGE
+})
+@Capability(
+		namespace = IMPLEMENTATION_NAMESPACE, 
+		name = RequireRuntimeAdapter.GECKO_REST_JERSEY_ADAPTER,
+		version = RequireRuntimeAdapter.GECKO_REST_JERSEY_ADAPTER_VERSION
+)
+public @interface ProvideRuntimeAdapter {
+	
+	@Attribute("provider")
+	String value();
+
+}

--- a/org.gecko.rest.jersey/src/org/gecko/rest/jersey/annotations/RequireJerseyExtras.java
+++ b/org.gecko.rest.jersey/src/org/gecko/rest/jersey/annotations/RequireJerseyExtras.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2012 - 2022 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made available under the terms of the 
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * Contributors:
+ *     Data In Motion - initial API and implementation
+ *     Stefan Bishof - API and implementation
+ *     Tim Ward - implementation
+ */
+package org.gecko.rest.jersey.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.osgi.annotation.bundle.Requirement;
+import org.osgi.annotation.bundle.Requirements;
+import org.osgi.framework.namespace.IdentityNamespace;
+
+/**
+ * Require the "extra" bits of Jersey that are actually mandatory
+ * @author Mark Hoffmann
+ * @since 07.11.2022
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({
+		ElementType.TYPE, ElementType.PACKAGE, ElementType.ANNOTATION_TYPE
+})
+@Requirements(value = {
+		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.inject.jersey-hk2"),
+		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.media.jersey-media-sse"),
+		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.media.jersey-media-jaxb"),
+		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "jakarta.validation.jakarta.validation-api")
+})
+public @interface RequireJerseyExtras {
+
+}

--- a/org.gecko.rest.jersey/src/org/gecko/rest/jersey/annotations/RequireJerseyServlet.java
+++ b/org.gecko.rest.jersey/src/org/gecko/rest/jersey/annotations/RequireJerseyServlet.java
@@ -24,7 +24,7 @@ import org.osgi.annotation.bundle.Requirements;
 import org.osgi.framework.namespace.IdentityNamespace;
 
 /**
- * 
+ * Require the "extra" bits of Jersey that are actually mandatory
  * @author Mark Hoffmann
  * @since 07.11.2022
  */
@@ -33,12 +33,13 @@ import org.osgi.framework.namespace.IdentityNamespace;
 @Target({
 		ElementType.TYPE, ElementType.PACKAGE
 })
+@RequireJerseyExtras
 @Requirements(value = {
-		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.inject.jersey-hk2"),
-		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.media.jersey-media-sse"),
-		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.media.jersey-media-jaxb"),
-		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "jakarta.validation.jakarta.validation-api")
+		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.core.jersey-common"),
+		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.core.jersey-server"),
+		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.containers.jersey-container-servlet-core"),
+		@Requirement(namespace = IdentityNamespace.IDENTITY_NAMESPACE, name = "org.glassfish.jersey.containers.jersey-container-servlet")
 })
-public @interface RequireJersey {
+public @interface RequireJerseyServlet {
 
 }

--- a/org.gecko.rest.jersey/src/org/gecko/rest/jersey/annotations/RequireRuntimeAdapter.java
+++ b/org.gecko.rest.jersey/src/org/gecko/rest/jersey/annotations/RequireRuntimeAdapter.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2012 - 2022 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made available under the terms of the 
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * Contributors:
+ *     Data In Motion - initial API and implementation
+ *     Stefan Bishof - API and implementation
+ *     Tim Ward - implementation
+ */
+package org.gecko.rest.jersey.annotations;
+
+import static org.osgi.namespace.implementation.ImplementationNamespace.IMPLEMENTATION_NAMESPACE;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.osgi.annotation.bundle.Requirement;
+
+/**
+ * Require a Runtime Adapter bundle to host the whiteboard on an underlying servlet runtime,
+ * 
+ * e.g. A Jetty server, or the OSGi Servlet Whiteboard
+ * 
+ * @author Mark Hoffmann
+ * @since 07.11.2022
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({
+		ElementType.TYPE, ElementType.PACKAGE
+})
+@Requirement(
+		namespace = IMPLEMENTATION_NAMESPACE, 
+		name = RequireRuntimeAdapter.GECKO_REST_JERSEY_ADAPTER,
+		version = RequireRuntimeAdapter.GECKO_REST_JERSEY_ADAPTER_VERSION
+)
+public @interface RequireRuntimeAdapter {
+	
+	public static final String GECKO_REST_JERSEY_ADAPTER = "org.gecko.rest.jersey.adapter";
+	public static final String GECKO_REST_JERSEY_ADAPTER_VERSION = "2.0.0";
+
+}

--- a/org.gecko.rest.jersey/src/org/gecko/rest/jersey/annotations/package-info.java
+++ b/org.gecko.rest.jersey/src/org/gecko/rest/jersey/annotations/package-info.java
@@ -1,0 +1,2 @@
+@org.osgi.annotation.bundle.Export
+package org.gecko.rest.jersey.annotations;

--- a/org.gecko.rest.jersey/src/org/gecko/rest/jersey/runtime/WhiteboardServletContainer.java
+++ b/org.gecko.rest.jersey/src/org/gecko/rest/jersey/runtime/WhiteboardServletContainer.java
@@ -23,6 +23,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.gecko.rest.jersey.annotations.RequireJerseyServlet;
 import org.gecko.rest.jersey.binder.PromiseResponseHandlerBinder;
 import org.gecko.rest.jersey.helper.DestroyListener;
 import org.gecko.rest.jersey.provider.jakartars.RuntimeDelegateService;
@@ -42,6 +43,7 @@ import org.glassfish.jersey.servlet.init.FilterUrlMappingsProviderImpl;
  * @author Juergen Albert
  * @since 1.0
  */
+@RequireJerseyServlet
 public class WhiteboardServletContainer extends ServletContainer {
 
 	/**

--- a/org.gecko.rest.jersey/src/org/gecko/rest/jersey/runtime/application/JerseyApplication.java
+++ b/org.gecko.rest.jersey/src/org/gecko/rest/jersey/runtime/application/JerseyApplication.java
@@ -86,6 +86,7 @@ public class JerseyApplication extends Application {
 	 * (non-Javadoc)
 	 * @see jakarta.ws.rs.core.Application#getSingletons()
 	 */
+	@SuppressWarnings("deprecation")
 	@Override
 	public Set<Object> getSingletons() {
 		Set<Object> resutlSingletons = new HashSet<>();

--- a/org.gecko.rest.jersey/src/org/gecko/rest/jersey/runtime/common/ClientBuilderComponent.java
+++ b/org.gecko.rest.jersey/src/org/gecko/rest/jersey/runtime/common/ClientBuilderComponent.java
@@ -13,13 +13,15 @@
  */
 package org.gecko.rest.jersey.runtime.common;
 
+import static org.osgi.namespace.service.ServiceNamespace.CAPABILITY_OBJECTCLASS_ATTRIBUTE;
+import static org.osgi.namespace.service.ServiceNamespace.SERVICE_NAMESPACE;
+import static org.osgi.resource.Namespace.EFFECTIVE_ACTIVE;
+
 import java.util.Dictionary;
 import java.util.Hashtable;
 
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.RxInvokerProvider;
-
 import org.gecko.rest.jersey.provider.JerseyConstants;
+import org.osgi.annotation.bundle.Capability;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -34,16 +36,36 @@ import org.osgi.service.condition.Condition;
 import org.osgi.service.jakartars.client.PromiseRxInvoker;
 import org.osgi.service.jakartars.client.SseEventSourceFactory;
 
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.RxInvokerProvider;
+
 /**
  * 
  * @author ilenia
  * @since Jun 11, 2020
  */
 @Component(immediate = true, 
-	service = ClientBuilderComponent.class, 
 	reference = @Reference(name = "runtimeCondition", 
 		service = Condition.class , 
 		target = JerseyConstants.JERSEY_RUNTIME_CONDITION)
+)
+@Capability(
+		namespace = SERVICE_NAMESPACE,
+		uses = ClientBuilder.class,
+		effective = EFFECTIVE_ACTIVE,
+		attribute = {
+				CAPABILITY_OBJECTCLASS_ATTRIBUTE + "=jakarta.ws.rs.client.ClientBuilder",
+				"service.scope=prototype"
+		}
+)
+@Capability(
+		namespace = SERVICE_NAMESPACE,
+		uses = SseEventSourceFactory.class,
+		effective = EFFECTIVE_ACTIVE,
+		attribute = {
+				CAPABILITY_OBJECTCLASS_ATTRIBUTE + "=org.osgi.service.jakartars.client.SseEventSourceFactory",
+				"service.scope=bundle"
+		}
 )
 public class ClientBuilderComponent {
 


### PR DESCRIPTION
* Remove osgi.contract capability which is not provided by the implementation
* Provide the implementation capability from the core, not each adapter
* Require an adapter from the core
* Use annotations to advertise services, not hardcoded lines in the bnd file

Signed-off-by: Tim Ward <timothyjward@apache.org>